### PR TITLE
do not default markdown h1s, h2s to use linked headings

### DIFF
--- a/src/components/markdown/typography.js
+++ b/src/components/markdown/typography.js
@@ -1,15 +1,14 @@
 /* eslint-disable no-unused-vars */
 import { Typography } from '@mui/joy'
-import { LinkedHeading } from '@components/linked-heading'
 
 // heading 1
 export const h1 = ({ node, ...props }) => (
-  <LinkedHeading level="h1" { ...props } />
+  <Typography level="h1" { ...props } />
 )
 
 // heading 2
 export const h2 = ({ node, ...props }) => (
-  <LinkedHeading level="h2" { ...props } />
+  <Typography level="h2" { ...props } />
 )
 
 // heading 3


### PR DESCRIPTION
so i'm now just realizing that those header links are a bit silly here, as there are no long content pages. this makes the markdown h1s and h2s _not_ default to use the LinkedHeading component